### PR TITLE
Update transform.py

### DIFF
--- a/oval/transform.py
+++ b/oval/transform.py
@@ -129,6 +129,10 @@ def definitions( advisories, rl_version ) :
     advisories.reset_index( )
     for _, advisory in advisories.iterrows( ) :
 
+        # filtering out non-RLSA types (following addition of RXSA)
+        if advisory[ 'name' ].split( '-' )[ 0 ] != "RLSA" :
+            continue
+
         severity = advisory[ 'synopsis' ].split( ':' )[ 0 ]
         issued = advisory[ 'publishedAt' ].split( 'T' )[ 0 ]
 


### PR DESCRIPTION
Accommodating new advisory type RXSA by skipping entries with this prefix as it is not a RLSA type.