### PR TITLE
added sa_type parameter to support SIGs

### DIFF
--- a/oval/control.py
+++ b/oval/control.py
@@ -83,13 +83,13 @@ def filter( advisories ) :
 
 
 
-def transform( advisories, rl_version ) :
+def transform( advisories, rl_version, sa_type ) :
     """
     transform advisories into definitions, tests, objects and states
     """
 
     # create a high-level definition for each advisory
-    definitions = xfrm.definitions( advisories, rl_version )
+    definitions = xfrm.definitions( advisories, rl_version, sa_type )
 
     # generate tests, objects and states from each high-level definition
     tests, objects, states = xfrm.generate( definitions, rl_version )

--- a/oval/oval.py
+++ b/oval/oval.py
@@ -3,6 +3,7 @@ ETL script for extracting security advisories, transforming content,
 and exporting it to OVAL compliant XML.
 """
 import sys
+import argparse
 
 from oval import control as ctrl
 from oval import xml
@@ -106,7 +107,7 @@ def output(definitions, tests, objects, states, rl_version):
     print(xml.footer())
 
 
-def pipeline(rl_version):
+def pipeline(rl_version, sa_type):
     """
     pipeline for gathering advisories, normalizing and filtering followed
     by transforming and XML output
@@ -122,7 +123,7 @@ def pipeline(rl_version):
     advisories = ctrl.filter(advisories)
 
     # transform to OVAL types
-    definitions, tests, objects, states = ctrl.transform(advisories, rl_version)
+    definitions, tests, objects, states = ctrl.transform(advisories, rl_version, sa_type)
 
     # output to OVAL XML content
     output(definitions, tests, objects, states, rl_version)
@@ -136,14 +137,14 @@ def main():
     @TODO - add error handling to stderr
     """
 
-    # get command line argument for version of rocky linux
-    if len(sys.argv) > 1:
-        rl_version = int(sys.argv[1])
-    else:
-        rl_version = 9
+    # get command line arguments for version of rocky linux and security advisory type
+    parser = argparse.ArgumentParser(description='Configuration parameters')
+    parser.add_argument('--rl_version', type=int, required=False, default=9, help='rocky linux version')
+    parser.add_argument('--sa_type', type=str, required=False, default='RLSA', help='security advisory type')
+    args = parser.parse_args()
 
     # pipeline conversion from JSON ingest to OVAL XML output
-    pipeline(rl_version)
+    pipeline(args.rl_version, args.sa_type)
 
 
 if __name__ == "__main__":

--- a/oval/oval.py
+++ b/oval/oval.py
@@ -9,7 +9,7 @@ from oval import control as ctrl
 from oval import xml
 
 
-def output(definitions, tests, objects, states, rl_version):
+def output(definitions, tests, objects, states, rl_version, sa_type):
     """
     output to OVAL XML content based on transformed content
     with definitions section followed by tests, objects, states
@@ -36,12 +36,12 @@ def output(definitions, tests, objects, states, rl_version):
             rl_version,
         )
 
-        criteria_output = xml.criteria(xml.version["Scope"], definition["criteria"])
+        criteria_output = xml.criteria(xml.version["Scope"].lower(), definition["criteria"])
 
         # definition content
         print(
             xml.definition(
-                xml.version["Scope"],
+                xml.version["Scope"].lower()+":",
                 definition["id"],
                 definition["version"],
                 definition["class"],
@@ -58,7 +58,7 @@ def output(definitions, tests, objects, states, rl_version):
         print(
             xml.test(
                 xml.version["Tag"],
-                xml.version["Scope"],
+                xml.version["Scope"].lower()+":",
                 test["type"],
                 test["id"],
                 test["version"],
@@ -77,7 +77,7 @@ def output(definitions, tests, objects, states, rl_version):
         print(
             xml.object(
                 xml.version["Tag"],
-                xml.version["Scope"],
+                xml.version["Scope"].lower()+":",
                 obj["type"],
                 obj["id"],
                 obj["version"],
@@ -93,7 +93,7 @@ def output(definitions, tests, objects, states, rl_version):
         print(
             xml.state(
                 xml.version["Tag"],
-                xml.version["Scope"],
+                xml.version["Scope"].lower()+":",
                 state["type"],
                 state["id"],
                 state["version"],
@@ -126,7 +126,7 @@ def pipeline(rl_version, sa_type):
     definitions, tests, objects, states = ctrl.transform(advisories, rl_version, sa_type)
 
     # output to OVAL XML content
-    output(definitions, tests, objects, states, rl_version)
+    output(definitions, tests, objects, states, rl_version, sa_type)
 
 
 def main():

--- a/oval/transform.py
+++ b/oval/transform.py
@@ -116,7 +116,7 @@ def references( cves, fixes, impact, public ) :
     return references
 
 
-def definitions( advisories, rl_version ) :
+def definitions( advisories, rl_version, sa_type ) :
     """
     walk the list of advisories and generate definitions which contain
     metadata and criteria (the later of which are used to create tests)
@@ -129,8 +129,8 @@ def definitions( advisories, rl_version ) :
     advisories.reset_index( )
     for _, advisory in advisories.iterrows( ) :
 
-        # filtering out non-RLSA types (following addition of RXSA)
-        if advisory[ 'name' ].split( '-' )[ 0 ] != "RLSA" :
+        # filtering out non-sa types (following addition of RXSA)
+        if advisory[ 'name' ].split( '-' )[ 0 ] != sa_type :
             continue
 
         severity = advisory[ 'synopsis' ].split( ':' )[ 0 ]
@@ -155,7 +155,7 @@ def definitions( advisories, rl_version ) :
         # create definition
         definitions.append( 
             { 
-                'id'          : advisory[ 'name' ].split( 'RLSA-' )[ 1 ].replace( ':', '' ), 
+                'id'          : advisory[ 'name' ].split( sa_type + '-' )[ 1 ].replace( ':', '' ), 
                 'version'     : transform_version[ 'Definition' ],
                 'title'       : advisory[ 'name' ] + ':'  + advisory[ 'synopsis' ].split( ':' )[ 1 ] + ' (' +  severity + ')',
                 'severity'    : severity,

--- a/oval/xml.py
+++ b/oval/xml.py
@@ -20,7 +20,7 @@ copyright = 'Copyright ' + str( publication_date.year ) + ' Rocky Enterprise Sof
 version = {
     'Product' : "1",
     'Schema'  : "5.10",
-    'Scope'   : "oval:org.rockylinux.rlsa:",
+    'Scope'   : "oval:org.rockylinux.",
     'Tag'     : "red-def:"
 }
 


### PR DESCRIPTION
By default, will generate Rocky Linux 9 with security advisory types of RLSA

New parameter parsing allows for different versions and SA types to support SIGs

--rl_version=[8|9]
--sa_type=[RLSA|RXSA]