### PR TITLE
use project.scripts instead of tool.poetry.scripts for entrypoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ requests = "~2.27.1"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry.scripts]
+[project.scripts]
 oval = "oval.oval:main"


### PR DESCRIPTION
This change updates the pyproject.toml to use the
PEP-621 specification for identifying console_scripts/entrypoints, and resolves the build issue on Fedora. From my testing, there is no impact for installations via e.g. pip, as these tools will understand PEP-621 entrypoint specifications.