### PR TITLE
Fixing invalid filepath in the rpmverifyfile_object rocky-linux/oval#18

### DIFF
--- a/oval/transform.py
+++ b/oval/transform.py
@@ -274,7 +274,7 @@ def generate_default( tests, objects, states, base_id, rl_version ) :
                 { 'name' : "version", 'pairs' : "", 'operation' : "pattern match", 'value' : "" },
                 { 'name' : "release", 'pairs' : "", 'operation' : "pattern match", 'value' : "" },
                 { 'name' : "arch", 'pairs' : "", 'operation' : "pattern match", 'value' : "" },
-                { 'name' : "filepath", 'pairs' : "", 'operation' : "pattern match", 'value' : "" }
+                { 'name' : "filepath", 'pairs': "", 'operation':"", 'value' : "/etc/rocky-release" }
             ]
         }
     )


### PR DESCRIPTION
This adds the correct for the `filepath` tag and removes the `operation="pattern match"` attribute which isn't needed on this tag. The resulted `rpmverifyfile_object` now looks like as expected:

```
  <red-def:rpmverifyfile_object id="oval:org.rockylinux.rlsa:obj:20234378001" version="1">
    <red-def:behaviors noconfigfiles="true" noghostfiles="true" nogroup="true" nolinkto="true" nomd5="true" nomode="true" nomtime="true" nordev="true" nosize="true" nouser="true"/>
    <red-def:name operation="pattern match"/>
    <red-def:epoch operation="pattern match"/>
    <red-def:version operation="pattern match"/>
    <red-def:release operation="pattern match"/>
    <red-def:arch operation="pattern match"/>
    <red-def:filepath>/etc/rocky-release</red-def:filepath>
  </red-def:rpmverifyfile_object>
```

Tested it by building a container with the provided `Containerfile` and then invoking it:
```
podman build -f Containerfile --rm -t rocky-oval .
podman run -it localhost/rocky-oval > oval.xml
```

As far as I can see the unit tests for this project just print things on stdout and don't really do any indepth assertions about the generated content. They also seem to contain imports which don't work, e.g.
https://github.com/rocky-linux/oval/blob/5a3b91445488cdbf22c0e7168dbdf01bb517141f/tests/control_test.py#L1
and
https://github.com/rocky-linux/oval/blob/5a3b91445488cdbf22c0e7168dbdf01bb517141f/tests/transform_test.py#L1

However, I've not tried to modify any of that as I don't fully understand how they are meant to be run and wanted to keep the diff at a minimum.