### PR TITLE
Append references to errata

### DIFF
--- a/oval/transform.py
+++ b/oval/transform.py
@@ -92,6 +92,18 @@ def references( cves, fixes, impact, public ) :
     references = [ ]
     for cve in cves :
         cve_id = cve[ 'name' ]
+        references.append(
+            { 
+                'id'      : cve_id, 
+                'url'     : cve[ 'sourceLink' ],
+                'source'  : cve[ 'sourceBy' ],
+                'cvss3'   : cve[ 'cvss3BaseScore' ] + cve[ 'cvss3ScoringVector' ],
+                'cwe'     : cve[ 'cwe' ],
+                'impact'  : impact,
+                'public'  : public,
+                'cve'     : cve_id
+            }
+        )
 
         # lookup bug for this cve (could be more efficient)
         for bug in bugs :
@@ -148,9 +160,10 @@ def definitions( advisories, rl_version ) :
         # create references
         refs = references( advisory[ 'cves' ], advisory[ 'fixes' ], severity.lower( ), issued.replace( '-', '' ) )
         for reference in refs :
-            id = reference[ 'bugdesc' ].split( ' ' )[ 0 ]
-            desc = reference[ 'bugdesc' ].replace( id, '' )
-            description = description + '*' + desc + '. (' + id + ')\n\n'
+            if 'bugdesc' in reference:
+                id = reference[ 'bugdesc' ].split( ' ' )[ 0 ]
+                desc = reference[ 'bugdesc' ].replace( id, '' )
+                description = description + '*' + desc + '. (' + id + ')\n\n'
 
         # create definition
         definitions.append( 

--- a/oval/xml.py
+++ b/oval/xml.py
@@ -159,9 +159,10 @@ def metadata( title, family, platforms, ref_id, source, references, description,
                '" impact="' + reference[ 'impact' ] + '" public="' + \
                reference[ 'public' ] + '">' + reference[ 'cve' ] + '</cve>\n'
 
-        bugs = bugs + \
-               '      <bugzilla href="' + reference[ 'bugref' ] + '" id="' + \
-               reference[ 'bugid' ] + '">' + reference[ 'bugdesc' ] + '</bugzilla>\n'
+        if 'bugref' in reference:
+            bugs = bugs + \
+                '      <bugzilla href="' + reference[ 'bugref' ] + '" id="' + \
+                reference[ 'bugid' ] + '">' + reference[ 'bugdesc' ] + '</bugzilla>\n'
 
     xml = xml + \
           cves + \


### PR DESCRIPTION
Current code was trying to match the `cve` from `fixes` field  with the `cves` list. The problem is the method of extracting `cve` name from the description doesn't work. In the current data the description is always empty. This results in no `cve` fields added to errata. In this PR I am adding the references for each of the `cve` we have discovered.  