### PR TITLE
Fix ingesting advisories

### DIFF
--- a/oval/control.py
+++ b/oval/control.py
@@ -39,7 +39,7 @@ def ingest( rl_version ) :
     """
 
     alist = []
-    page = 1
+    page = 0
     while True:
         product_filter = f"&filters.product=Rocky%20Linux%20{rl_version}"
         url = f"{BASEAPI}{BASEFILTER}{product_filter}&page={page}&limit={PER_RQ_LIMIT}"


### PR DESCRIPTION
The advisories were downloaded starting from `page = 1`, which is incorrect as the paging starts from 0.